### PR TITLE
Fix insec

### DIFF
--- a/blockutils.lsp
+++ b/blockutils.lsp
@@ -59,7 +59,6 @@
   (setq oldlayer (getvar "clayer"))
   (setvar "clayer" "symb")
   (command ".insert" "section marker_anno" pause "" "" "")
-  (command ".rotate" (entlast) "" (getvar "lastpoint") "180")
   (setvar "clayer" oldlayer)
   (princ))
 


### PR DESCRIPTION
The rotate command made the text upside-down, which is bad.