### PR TITLE
Improve intitle

### DIFF
--- a/blockutils.lsp
+++ b/blockutils.lsp
@@ -42,7 +42,11 @@
   (setq oldlayer (getvar "clayer"))
   (setvar "clayer" "symb")
   (command ".insert" "title bar_anno" pause "" "" ""
-	   "" "" "" (getvar "cannoscale"))
+	   "" "" ""
+	   (if (and (/= "Model" (getvar "ctab"))
+		    (= 1 (getvar "cvport")))
+	       "1'-0\" = 1'-0\""
+	       (getvar "cannoscale")))
   (setvar "clayer" oldlayer)
   (princ))
 


### PR DESCRIPTION
Now when inserting a title bar in paper space, it will
have the scale 1'-0" = 1'-0" instead of 1:1